### PR TITLE
feat: public archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 - [feat](d9abefeffb75cc4af5be42a5886166397c1ec988): renamed endpoints that can handle URL identifiers.
 
 The new endpoints enable that the url identifier of an asset is passed along to the metadata, preview or rendition renderer.
+
+- [feat](7b2d1789e194d0166ab56e6402bd9d888254afe1): configure `PUBLIC_ARCHIVES` as a subset of `FOTOWARE_ARCHIVES`.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Unauthenticated endpoints:
 
 Authenticated endpoints, only required if asset is not public:
 
-- `GET /-/about?resource` renders asset metadata[¹](#fn1)
-  - `GET /-/doc?resource,format=html|json` renders a preview page or a JSON description[¹](#fn1)
+- `GET /-/about?resource` renders asset metadata
+  - `GET /-/doc?resource,format=html|json` renders a preview page or a JSON description
 - `GET /-/asset/preview?resource,size,w,h,square` renders a preview (images and documents)[²](#fn2)
 - `GET /-/asset/render?resource,original,profile,size,w,h` renders a specific rendition (images only)[²](#fn2)
 
@@ -90,8 +90,15 @@ Ensure that a single asset only appears in a single archive.
 
 <small>
 
-<a id="fn1" href="#fn1">1:</a> Unauthenticated only for the public document types configured in `PUBLIC_DOCTYPES` or `PUBLIC_METADATA_KEY_VALUE`. Supply a valid token for non-public assets. Else, a HTML file manifest with a link to Fotoware (HTTP status 401 Unauthorized).  
-<a id="fn2" href="#fn2">2:</a> Unauthenticated only for the public document types configured in `PUBLIC_DOCTYPES` or `PUBLIC_METADATA_KEY_VALUE`. Supply a valid token for non-public assets. Else, an empty HTTP 401 Unauthorized is returned.  
+<a id="fn1" href="#fn1">1:</a> Public are those assets for which
+the document type is `PUBLIC_DOCTYPES`,
+_OR_ the `PUBLIC_METADATA_KEY_VALUE` matches,
+_OR_ its archive is in `PUBLIC_ARCHIVES`.
+All other assets are not public.
+Else, a HTML file manifest with a link to Fotoware (HTTP status 401 Unauthorized).  
+<a id="fn2" href="#fn2">2:</a> Unauthenticated only for for public assets[¹](#fn1).
+Supply a valid token for non-public assets.
+Else, an empty HTTP 401 Unauthorized is returned.  
 <a id="fn3" href="#fn3">3:</a> The value space was chosen to be shorter (27 chars) than a regular UUID (36 chars).
 The ID value space was based on the choice of a globally random UUID.
 The hex encoding of a UUID is 36 chars long, but with somewhat low entropy: only [0-9a-f] are used.

--- a/app/config.py
+++ b/app/config.py
@@ -87,6 +87,15 @@ PUBLIC_DOCTYPES = os.getenv("PUBLIC_DOCTYPES", "").split()
 """
 A whitespace separated list of doctypes that do not require authenticated access.
 Reference: <https://learn.fotoware.com/Integrations_and_APIs/001_The_FotoWare_API/FotoWare_API_Overview/Document_Types>
+
+PUBLIC_DOCTYPES, PUBLIC_ARCHIVES and PUBLIC_METADATA_KEY_VALUE work complimentary.
+If an asset matches on ANY of these PUBLIC_* keys, it is determined public.
+"""
+
+PUBLIC_ARCHIVES = os.getenv("PUBLIC_ARCHIVES", "").split()
+"""
+A whitespace separated list of archive IDs that are fully publicly accessible.
+This must be a subset of the archives in FOTOWARE_ARCHIVES.
 """
 
 PUBLIC_METADATA_KEY, PUBLIC_METADATA_VALUE = os.getenv(

--- a/app/fotoware/apitypes.py
+++ b/app/fotoware/apitypes.py
@@ -65,6 +65,7 @@ class Asset(TypedDict):
     previews: list[AssetPreview]
     previewToken: str
     renditions: list[AssetRendition]
+    archiveId: int
 
 
 class ImageExport(TypedDict):

--- a/app/fotoware/assets.py
+++ b/app/fotoware/assets.py
@@ -3,7 +3,12 @@ from asyncio import sleep
 import aiohttp
 from fastapi import HTTPException, status
 
-from ..config import PUBLIC_DOCTYPES, PUBLIC_METADATA_KEY, PUBLIC_METADATA_VALUE
+from ..config import (
+    PUBLIC_DOCTYPES,
+    PUBLIC_METADATA_KEY,
+    PUBLIC_METADATA_VALUE,
+    PUBLIC_ARCHIVES,
+)
 from . import api
 from .apitypes import Asset
 from .log import FotowareLog
@@ -12,10 +17,17 @@ ASSET_DOCTYPE = ["image", "movie", "audio", "document", "graphic", "generic"]
 NUM_CONNECTION_RETRIES = 10
 
 
-def is_public(asset: Asset):
-    return asset.get("doctype") in PUBLIC_DOCTYPES or (
-        asset.get("metadata", {}).get(PUBLIC_METADATA_KEY, {}).get("value")
-        == PUBLIC_METADATA_VALUE
+def is_public(asset: Asset) -> bool:
+    """
+    True if an Asset's document type OR archive OR metadata value allows it to be public.
+    """
+    return any(
+        [
+            asset.get("doctype") in PUBLIC_DOCTYPES,
+            str(asset.get("archiveId")) in PUBLIC_ARCHIVES,
+            asset.get("metadata", {}).get(PUBLIC_METADATA_KEY, {}).get("value")
+            == PUBLIC_METADATA_VALUE,
+        ]
     )
 
 


### PR DESCRIPTION
This PR enables the configuration of `PUBLIC_ARCHIVES` as a subset of `FOTOWARE_ARCHIVES`.

For some FotoWare configurations, that may simplify usage and setup.
